### PR TITLE
Add encoder decoder utilization metrics

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -127,6 +127,22 @@ nvmlReturn_t nvmlDeviceGetFanSpeed(nvmlDevice_t device, unsigned int *speed) {
   return nvmlDeviceGetFanSpeedFunc(device, speed);
 }
 
+nvmlReturn_t (*nvmlDeviceGetEncoderUtilizationFunc)(nvmlDevice_t device, unsigned int* utilization, unsigned int* samplingPeriodUs);
+nvmlReturn_t nvmlDeviceGetEncoderUtilization(nvmlDevice_t device, unsigned int* utilization, unsigned int* samplingPeriodUs) {
+  if (nvmlDeviceGetEncoderUtilizationFunc == NULL) {
+    return NVML_ERROR_FUNCTION_NOT_FOUND;
+  }
+  return nvmlDeviceGetEncoderUtilizationFunc(device, utilization, samplingPeriodUs);
+}
+
+nvmlReturn_t (*nvmlDeviceGetDecoderUtilizationFunc)(nvmlDevice_t device, unsigned int* utilization, unsigned int* samplingPeriodUs);
+nvmlReturn_t nvmlDeviceGetDecoderUtilization(nvmlDevice_t device, unsigned int* utilization, unsigned int* samplingPeriodUs) {
+  if (nvmlDeviceGetDecoderUtilizationFunc == NULL) {
+    return NVML_ERROR_FUNCTION_NOT_FOUND;
+  }
+  return nvmlDeviceGetDecoderUtilizationFunc(device, utilization, samplingPeriodUs);
+}
+
 nvmlReturn_t (*nvmlDeviceGetSamplesFunc)(nvmlDevice_t device, nvmlSamplingType_t type, unsigned long long lastSeenTimeStamp, nvmlValueType_t *sampleValType, unsigned int *sampleCount, nvmlSample_t *samples);
 
 // Loads the "libnvidia-ml.so.1" shared library.
@@ -197,6 +213,14 @@ nvmlReturn_t nvmlInit_dl(void) {
   if (nvmlDeviceGetSamplesFunc == NULL) {
     return NVML_ERROR_FUNCTION_NOT_FOUND;
   }
+  nvmlDeviceGetEncoderUtilizationFunc = dlsym(nvmlHandle, "nvmlDeviceGetEncoderUtilization");
+  if (nvmlDeviceGetEncoderUtilizationFunc == NULL) {
+    return NVML_ERROR_FUNCTION_NOT_FOUND;
+  }
+  nvmlDeviceGetDecoderUtilizationFunc = dlsym(nvmlHandle, "nvmlDeviceGetDecoderUtilization");
+  if (nvmlDeviceGetDecoderUtilizationFunc == NULL) {
+    return NVML_ERROR_FUNCTION_NOT_FOUND;
+  } 
   nvmlReturn_t result = nvmlInitFunc();
   if (result != NVML_SUCCESS) {
     dlclose(nvmlHandle);
@@ -473,4 +497,28 @@ func (d Device) FanSpeed() (uint, error) {
 	var n C.uint
 	r := C.nvmlDeviceGetFanSpeed(d.dev, &n)
 	return uint(n), errorString(r)
+}
+
+// EncoderUtilization returns the percentage of utilization and sampling size in microseconds for the Encoder,
+// the first return value is the percentage of utilization, the second return value is the sampling size in microseconds 
+func (d Device) EncoderUtilization() (uint, uint, error) {
+	if C.nvmlHandle == nil {
+		return 0, 0, errLibraryNotLoaded
+  }
+  var n C.uint
+  var sp C.uint
+  r := C.nvmlDeviceGetEncoderUtilization(d.dev, &n, &sp)
+  return uint(n), uint(sp), errorString(r) 
+}
+
+// DecoderUtilization returns the percentage of utilization and sampling size in microseconds for the Decoder,
+// the first return value is the percentage of utilization, the second return value is the sampling size in microseconds 
+func (d Device) DecoderUtilization() (uint, uint, error){
+	if C.nvmlHandle == nil {
+		return 0, 0, errLibraryNotLoaded
+  }
+  var n C.uint
+  var sp C.uint
+  r := C.nvmlDeviceGetDecoderUtilization(d.dev, &n, &sp)
+  return uint(n), uint(sp), errorString(r) 
 }

--- a/bindings.go
+++ b/bindings.go
@@ -220,7 +220,7 @@ nvmlReturn_t nvmlInit_dl(void) {
   nvmlDeviceGetDecoderUtilizationFunc = dlsym(nvmlHandle, "nvmlDeviceGetDecoderUtilization");
   if (nvmlDeviceGetDecoderUtilizationFunc == NULL) {
     return NVML_ERROR_FUNCTION_NOT_FOUND;
-  } 
+  }
   nvmlReturn_t result = nvmlInitFunc();
   if (result != NVML_SUCCESS) {
     dlclose(nvmlHandle);
@@ -499,26 +499,26 @@ func (d Device) FanSpeed() (uint, error) {
 	return uint(n), errorString(r)
 }
 
-// EncoderUtilization returns the percentage of utilization and sampling size in microseconds for the Encoder,
-// the first return value is the percentage of utilization, the second return value is the sampling size in microseconds 
+// EncoderUtilization returns the percent of time over the last sample period during which the GPU video encoder was being used.
+// The sampling period is variable and is returned in the second return argument in microseconds.
 func (d Device) EncoderUtilization() (uint, uint, error) {
 	if C.nvmlHandle == nil {
 		return 0, 0, errLibraryNotLoaded
-  }
-  var n C.uint
-  var sp C.uint
-  r := C.nvmlDeviceGetEncoderUtilization(d.dev, &n, &sp)
-  return uint(n), uint(sp), errorString(r) 
+	}
+	var n C.uint
+	var sp C.uint
+	r := C.nvmlDeviceGetEncoderUtilization(d.dev, &n, &sp)
+	return uint(n), uint(sp), errorString(r)
 }
 
-// DecoderUtilization returns the percentage of utilization and sampling size in microseconds for the Decoder,
-// the first return value is the percentage of utilization, the second return value is the sampling size in microseconds 
-func (d Device) DecoderUtilization() (uint, uint, error){
+// DecoderUtilization returns the percent of time over the last sample period during which the GPU video decoder was being used.
+// The sampling period is variable and is returned in the second return argument in microseconds.
+func (d Device) DecoderUtilization() (uint, uint, error) {
 	if C.nvmlHandle == nil {
 		return 0, 0, errLibraryNotLoaded
-  }
-  var n C.uint
-  var sp C.uint
-  r := C.nvmlDeviceGetDecoderUtilization(d.dev, &n, &sp)
-  return uint(n), uint(sp), errorString(r) 
+	}
+	var n C.uint
+	var sp C.uint
+	r := C.nvmlDeviceGetDecoderUtilization(d.dev, &n, &sp)
+	return uint(n), uint(sp), errorString(r)
 }

--- a/cmd/example/example.go
+++ b/cmd/example/example.go
@@ -127,12 +127,14 @@ func main() {
 		encoderUtilization, _, err := dev.EncoderUtilization()
 		if err != nil {
 			fmt.Printf("\tdev.EncoderUtilization() error: %v\n", err)
+			return
 		}
 		fmt.Printf("\tutilization.encoder: %d\n", encoderUtilization)
 
 		decoderUtilization, _, err := dev.DecoderUtilization()
 		if err != nil {
 			fmt.Printf("\tdev.DecoderUtilization() error: %v\n", err)
+			return
 		}
 		fmt.Printf("\tutilization.decoder: %d\n", decoderUtilization)
 		fmt.Println()

--- a/cmd/example/example.go
+++ b/cmd/example/example.go
@@ -123,6 +123,18 @@ func main() {
 			return
 		}
 		fmt.Printf("\tfan.speed: %v%%\n", fanSpeed)
+
+		encoderUtilization, _, err := dev.EncoderUtilization()
+		if err != nil {
+			fmt.Printf("\tdev.EncoderUtilization() error: %v\n", err)
+		}
+		fmt.Printf("\tutilization.encoder: %d\n", encoderUtilization)
+
+		decoderUtilization, _, err := dev.DecoderUtilization()
+		if err != nil {
+			fmt.Printf("\tdev.DecoderUtilization() error: %v\n", err)
+		}
+		fmt.Printf("\tutilization.decoder: %d\n", decoderUtilization)
 		fmt.Println()
 	}
 }


### PR DESCRIPTION
This repo is a great job! 

Since our company use nvidia gpu with ffmpeg library to encode and decode videos, so we need to add functions to get metrics about encoder utilization and decoder utilization.