### PR TITLE
Stub out library when not built with cgo enabled

### DIFF
--- a/bindings_unsupported.go
+++ b/bindings_unsupported.go
@@ -1,0 +1,121 @@
+// +build !cgo
+
+package gonvml
+
+import (
+	"errors"
+	"time"
+)
+
+const (
+	szDriver = 0
+	szName   = 0
+	szUUID   = 0
+)
+
+var errLibraryNotLoaded = errors.New("this binary is built without CGO, NVML is disabled")
+
+// Initialize initializes NVML.
+// Call this before calling any other methods.
+func Initialize() error {
+	return errLibraryNotLoaded
+}
+
+// Shutdown shuts down NVML.
+// Call this once NVML is no longer being used.
+func Shutdown() error {
+	return errLibraryNotLoaded
+}
+
+// SystemDriverVersion returns the the driver version on the system.
+func SystemDriverVersion() (string, error) {
+	return "", errLibraryNotLoaded
+}
+
+// DeviceCount returns the number of nvidia devices on the system.
+func DeviceCount() (uint, error) {
+	return 0, errLibraryNotLoaded
+}
+
+// Device is the handle for the device.
+// This handle is obtained by calling DeviceHandleByIndex().
+type Device struct {
+}
+
+// DeviceHandleByIndex returns the device handle for a particular index.
+// The indices range from 0 to DeviceCount()-1. The order in which NVML
+// enumerates devices has no guarantees of consistency between reboots.
+func DeviceHandleByIndex(idx uint) (Device, error) {
+	return Device{}, errLibraryNotLoaded
+}
+
+// MinorNumber returns the minor number for the device.
+// The minor number for the device is such that the Nvidia device node
+// file for each GPU will have the form /dev/nvidia[minor number].
+func (d Device) MinorNumber() (uint, error) {
+	return 0, errLibraryNotLoaded
+}
+
+// UUID returns the globally unique immutable UUID associated with this device.
+func (d Device) UUID() (string, error) {
+	return "", errLibraryNotLoaded
+}
+
+// Name returns the product name of the device.
+func (d Device) Name() (string, error) {
+	return "", errLibraryNotLoaded
+}
+
+// MemoryInfo returns the total and used memory (in bytes) of the device.
+func (d Device) MemoryInfo() (uint64, uint64, error) {
+	return 0, 0, errLibraryNotLoaded
+}
+
+// UtilizationRates returns the percent of time over the past sample period during which:
+// utilization.gpu: one or more kernels were executing on the GPU.
+// utilizatoin.memory: global (device) memory was being read or written.
+func (d Device) UtilizationRates() (uint, uint, error) {
+	return 0, 0, errLibraryNotLoaded
+}
+
+// PowerUsage returns the power usage for this GPU and its associated circuitry
+// in milliwatts. The reading is accurate to within +/- 5% of current power draw.
+func (d Device) PowerUsage() (uint, error) {
+	return 0, errLibraryNotLoaded
+}
+
+// AveragePowerUsage returns the power usage for this GPU and its associated circuitry
+// in milliwatts averaged over the samples collected in the last `since` duration.
+func (d Device) AveragePowerUsage(since time.Duration) (uint, error) {
+	return 0, errLibraryNotLoaded
+}
+
+// AverageGPUUtilization returns the utilization.gpu metric (percent of time
+// one of more kernels were executing on the GPU) averaged over the samples
+// collected in the last `since` duration.
+func (d Device) AverageGPUUtilization(since time.Duration) (uint, error) {
+	return 0, errLibraryNotLoaded
+}
+
+// Temperature returns the temperature for this GPU in Celsius.
+func (d Device) Temperature() (uint, error) {
+	return 0, errLibraryNotLoaded
+}
+
+// FanSpeed returns the temperature for this GPU in the percentage of its full
+// speed, with 100 being the maximum.
+func (d Device) FanSpeed() (uint, error) {
+	return 0, errLibraryNotLoaded
+}
+
+// EncoderUtilization returns the percent of time over the last sample period during which the GPU video encoder was being used.
+// The sampling period is variable and is returned in the second return argument in microseconds.
+func (d Device) EncoderUtilization() (uint, uint, error) {
+	return 0, 0, errLibraryNotLoaded
+}
+
+// DecoderUtilization returns the percent of time over the last sample period during which the GPU video decoder was being used.
+// The sampling period is variable and is returned in the second return argument in microseconds.
+func (d Device) DecoderUtilization() (uint, uint, error) {
+	return 0, 0, errLibraryNotLoaded
+}


### PR DESCRIPTION
GoNVML depends on C code so it (and everything that depends on it) is currently not buildable with cgo disabled. Since its API design assumes that everything can fail anyways if the NVML is not available this makes it possible to just always fail if cgo is disabled. That also makes sense since systems without C standard library will not be able to run NVML anyways.

I've modified the `errLibraryNotLoaded` message in the `bindings_unsupported.go` file, that way it is clear to the user when he runs into an initialization error that the error is caused by not using cgo to build his binary.